### PR TITLE
[임지수] 1-4 문제풀이(1158)

### DIFF
--- a/src/chapter1/4_기초자료구조(2)/임지수/1158_python_임지수.py
+++ b/src/chapter1/4_기초자료구조(2)/임지수/1158_python_임지수.py
@@ -1,0 +1,14 @@
+import sys
+
+input = sys.stdin.readline
+
+from collections import deque
+
+N, K = map(int, input().rstrip().split())
+ary = deque(range(1, N+1))
+
+print('<', end='')
+for _ in range(N-1):
+    ary.rotate(-(K-1))
+    print(ary.popleft(), end=', ')
+print(ary.popleft(), end='>')


### PR DESCRIPTION
## ❓1158번 : 요세푸스 문제

### 🔡 코드

```python
import sys

input = sys.stdin.readline

from collections import deque

N, K = map(int, input().rstrip().split())
ary = deque(range(1, N+1))

print('<', end='')
for _ in range(N-1):
    ary.rotate(-(K-1))
    print(ary.popleft(), end=', ')
print(ary.popleft(), end='>')
```

### 🤨 접근법

1부터 N까지의 배열에서 K번 째 수들을 꺼내 수열을 만들면 되는 문제, 리스트에서 remove(K)를 하면 복잡도가 O(N)이기 때문에 다른 방법을 생각해야할 것 같았다.

deque의 rotate를 활용한 방법을 생각했다. deque의 rotate(k)는 k만큼 덱을 회전시키며, 인자로 k를 주면 오른쪽, -k를 주면 왼쪽으로 회전한다. 따라서 본 문제에서 배열을 K-2만큼 왼쪽으로 회전시키고 맨 앞 원소를 꺼내면(deque의 경우 O(1)) 된다. 

deque은 이중연결리스트이기 때문에 rotate 연산시 이론상 시간복잡도는 O(1)이지만 공간복잡도가 O(k)이다. 따라서 배열의 원소가 극단적으로 많지 않을 때 좋은 방법 같다.