### PR TITLE
[임지수] 1-4 문제풀이(1966)

### DIFF
--- a/src/chapter1/4_기초자료구조(2)/임지수/1966_python_임지수.py
+++ b/src/chapter1/4_기초자료구조(2)/임지수/1966_python_임지수.py
@@ -1,0 +1,26 @@
+import sys
+input = sys.stdin.readline
+
+from collections import deque
+
+num_of_testcase = int(input())
+for _ in range(num_of_testcase):
+    N, M = map(int, input().rstrip().split())
+    docs = deque(map(int, input().rstrip().split()))
+    maxPriority = max(docs)
+    count = 1
+
+    while True:
+        if docs[0] >= maxPriority:
+            if M == 0:
+                break
+            else:
+                docs.popleft()
+                count += 1
+                M = (M+len(docs)-1)%len(docs)
+                maxPriority = max(docs)
+        else:
+            docs.rotate(-1)
+            M = (M + len(docs) - 1) % len(docs)
+
+    print(count)


### PR DESCRIPTION
## ❓1966번 : 프린터 큐

### 🔡 코드

```python
import sys
input = sys.stdin.readline

from collections import deque

num_of_testcase = int(input())
for _ in range(num_of_testcase):
    N, M = map(int, input().rstrip().split())
    docs = deque(map(int, input().rstrip().split()))
    maxPriority = max(docs)
    count = 1

    while True:
        if docs[0] >= maxPriority:
            if M == 0:
                break
            else:
                docs.popleft()
                count += 1
                M = (M+len(docs)-1)%len(docs)
                maxPriority = max(docs)
        else:
            docs.rotate(-1)
            M = (M + len(docs) - 1) % len(docs)

    print(count)
```

### 🤨 접근법

숫자(우선순위)를 원소로 가지는 큐에서 pop 연산 수행 시 큐에서 가장 큰 숫자가 아니면 맨 뒤로 보내버릴 때 알고 싶은 인덱스가 몇 번째로 pop되는지 출력하는 문제

알고 싶은 인덱스는 `M`으로 계속 두고 큐 내 원소 변경 시 `M`도 맞춰서 조정해줘야한다.

매 반복마다 가장 앞에 있는 원소와 큐에서 가장 큰 수를 비교해서 앞의 원소가 더 작으면 rotate(-1)로 왼쪽으로 한칸 회전 → 이 때 모듈러(%) 연산으로 M 인덱스도 회전할 수 있도록 한다.

맨 앞 원소가 최대 우선순위면 pop하되, 이 때 `M`이 0이면 맨 앞 원소는 알고 싶은 인덱스에 해당하므로 반복 종료 후 `count` 반환
`M`이 0이 아니라면 `count` 증가 후 `M` 인덱스를 조정한다.