### PR TITLE
[임지수] 1-4 문제풀이(5430)

### DIFF
--- a/src/chapter1/4_기초자료구조(2)/임지수/5430_python_임지수.py
+++ b/src/chapter1/4_기초자료구조(2)/임지수/5430_python_임지수.py
@@ -1,0 +1,24 @@
+import sys
+import re
+from collections import deque
+input = sys.stdin.readline
+
+num_of_testCase = int(input().rstrip())
+for _ in range(num_of_testCase):
+    funcs = list(input().rstrip())
+    n = int(input().rstrip())
+    ary = deque(re.findall('[0-9]+', input().rstrip()))
+    reverse = False
+    for func in funcs:
+        if func == 'R':
+            reverse = not reverse
+        else:
+            if ary:
+                ary.popleft() if not reverse else ary.pop()
+            else:
+                ary = 'error'
+                break
+    if ary != 'error':
+        print('[' + ','.join(ary) + ']') if not reverse else print('['+','.join(reversed(ary))+']')
+    else:
+        print('error')


### PR DESCRIPTION
## ❓5430번 문제 : AC

### 🔡 코드

```python
import sys
import re
from collections import deque
input = sys.stdin.readline

num_of_testCase = int(input().rstrip())
for _ in range(num_of_testCase):
    funcs = list(input().rstrip())
    n = int(input().rstrip())
    ary = deque(re.findall('[0-9]+', input().rstrip()))
    reverse = False
    for func in funcs:
        if func == 'R':
            reverse = not reverse
        else:
            if ary:
                ary.popleft() if not reverse else ary.pop()
            else:
                ary = 'error'
                break
    if ary != 'error':
        print('[' + ','.join(ary) + ']') if not reverse else print('['+','.join(reversed(ary))+']')
    else:
        print('error')
```

### 🤨 접근법

기본적으로 명령어 ‘R’일 때 배열을 뒤집고, ‘D’일 때 맨 앞 원소를 제거하면 되는 문제이다. 원소 제거 시 deque을 활용해 복잡도는 O(1)지만 배열을 뒤집을 때 리스트 슬라이싱([::-1])이나 reverse() 함수를 사용하게 되면 시간 초과가 발생한다.

배열이 주어질 때 ‘[1, 2, 3, 4]’와 같은 문자열의 형태로 주어지게 되는데, 메모리 상에서 덱으로 활용하기 위해 문자열을 파싱해야 한다. 정규표현식(re)으로 문자열에서 숫자만 파싱할 수 있도록 했다.(split(’,’) 메서드로도 가능하다)

생각해보면 deque을 활용했기 때문에 pop, popleft로 O(1) 양방향 원소 제거가 가능하다. 따라서 실제 배열을 뒤집지 않고 뒤집는다고 생각만 하면 된다. 이를 위해 `reverse`라는 flag 인자를 두었다.

`reverse`가 True라면 배열이 뒤집혔다는 의미로, 맨 앞 원소를 제거하기 위해 pop()을 활용해야 한다.반대로 `reverse`가 False라면 기존처럼 맨 앞 원소를 제거하기 위해 popleft()를 활용한다.

마지막 출력 시에도 이를 고려해야 하는데, `reverse`가 True라면 출력시에는 진짜로 뒤집혀서 출력해야 하므로 한 번의 reverse() 함수를 호출하여 뒤집어서 출력할 수 있도록 했다

## 📖 고찰

reverse 연산도 최소 O(n)임을 기억해서 시간 효율을 고려해야 하는 문제에 대해 이번 문제처럼 접근할 수 있도록 하자. 양방향으로 O(1) 출력이 가능한 deque의 이점을 최대로 활용하는 방법인 것 같다.

예전에 정리해뒀던 정규 표현식을 활용할 수 있었다. 다만 메타문자를 대부분 까먹었는데, 문자열 파싱에 활용할 수 있는 최소한의 메타문자를 다시 정리해두면 좋을 것 같다.(코테나 면접 전에 이 부분 검토)