### PR TITLE
[임지수] 2-1 문제 풀이(1182)

### DIFF
--- a/src/chapter2/1_백트래킹(1)/1182_python_임지수.py
+++ b/src/chapter2/1_백트래킹(1)/1182_python_임지수.py
@@ -1,0 +1,76 @@
+'''
+import sys
+input = sys.stdin.readline
+
+from itertools import combinations
+
+N, S = map(int, input().rstrip().split())
+nums = list(map(int, input().rstrip().split()))
+count = 0
+
+for i in range(1, N+1):
+    comb = combinations(nums, i)
+    for p in comb:
+        if sum(p) == S:
+            count += 1
+
+print(count)
+'''
+
+
+import sys
+input = sys.stdin.readline
+
+count = 0
+N, S = map(int, input().rstrip().split())
+nums = list(map(int, input().rstrip().split()))
+visited = [False for _ in range(N)]
+
+def dfs(sequence, sequence_size, idx, visited):
+    global count
+
+    if len(sequence) == sequence_size:
+        if sum(sequence) == S:
+            count += 1
+        return
+
+    for i in range(idx, len(nums)):
+        if not visited[i]:
+            visited[i] = True
+            sequence.append(nums[i])
+            dfs(sequence, sequence_size, i, visited)
+
+            sequence.pop()
+            visited[i] = False
+
+for SEQUENCE_SIZE in range(1, N+1):
+    dfs([], SEQUENCE_SIZE, 0, visited)
+
+print(count)
+
+
+'''
+import sys
+input = sys.stdin.readline
+
+count = 0
+N, S = map(int, input().rstrip().split())
+nums = list(map(int, input().rstrip().split()))
+
+def back_tracking(idx, res):
+    global count
+
+    if idx >= N:
+        return
+
+    res += nums[idx]
+
+    if res == S:
+        count += 1
+
+    back_tracking(idx+1, res)
+    back_tracking(idx+1, res-nums[idx])
+
+back_tracking(0, 0)
+print(count)
+'''


### PR DESCRIPTION
# 1182번 : 부분수열의 합

개의 정수로 이루어진 수열이 있을 때, 크기가 양수인 부분수열 중에서 그 수열의 원소를 다 더한 값이 S가 되는 경우의 수를 구하면 되는 문제

## 풀이 1 : combinations 활용

### 🔡 코드

```python
import sys
input = sys.stdin.readline

from itertools import combinations

N, S = map(int, input().rstrip().split())
nums = list(map(int, input().rstrip().split()))
count = 0

for i in range(1, N+1):
    comb = combinations(nums, i)
    for p in comb:
        if sum(p) == S:
            count += 1

print(count)
```

### 🤨 접근법

길이가 1부터 N까지인 모든 부분 수열을 고려하기 위해 조합을 활용, N개중에서 i(1, …, N)개를 뽑는 경우의수를 구해서 각 경우의 수를 모두 더했을 때 S가 되는 경우를 카운트했다.

## 풀이 2 : 백트래킹 활용

### 🔡 코드

```python
import sys
input = sys.stdin.readline

count = 0
N, S = map(int, input().rstrip().split())
nums = list(map(int, input().rstrip().split()))
visited = [False for _ in range(N)]

def dfs(sequence, sequence_size, idx, visited):
    global count

    if len(sequence) == sequence_size:
        if sum(sequence) == S:
            count += 1
        return

    for i in range(idx, len(nums)):
        if not visited[i]:
            visited[i] = True
            sequence.append(nums[i])
            dfs(sequence, sequence_size, i, visited)

            sequence.pop()
            visited[i] = False

for SEQUENCE_SIZE in range(1, N+1):
    dfs([], SEQUENCE_SIZE, 0, visited)

print(count)
```

### 🤨 접근법

[[이전 문제](https://www.notion.so/6e14f0f9dcea44f79a49ac32b5f3f338)](https://www.notion.so/6e14f0f9dcea44f79a49ac32b5f3f338)와 동일하게 DFS+백트래킹으로 접근했다. 모든 길이의 부분수열을 고려하기 위해서 최대 수열 크기(`SEQUENCE_SIZE`)를 증가해가며 DFS를 하도록 했다. 

인덱스(`idx`)를 하나씩 늘려가며 현재 부분 수열(`sequence`)에 넣어보고 검사 후 빼보는 과정을 반복한다. 

## 풀이 3 : 조금 더 간결한 백트래킹(참고)

### 🔡 코드

```python
import sys
input = sys.stdin.readline

count = 0
N, S = map(int, input().rstrip().split())
nums = list(map(int, input().rstrip().split()))

def back_tracking(idx, res):
    global count

    if idx >= N:
        return

    res += nums[idx]

    if res == S:
        count += 1

    back_tracking(idx+1, res)
    back_tracking(idx+1, res-nums[idx])

back_tracking(0, 0)
print(count)
```

### 🤨 접근법

내가 이해한 백트래킹을 가장 직관이고 간결하게 풀이한 것 같아 참고한 방법이다.

인덱스를 하나씩 늘려서 합을 더해보고 현재 재귀에서 해당 인덱스의 값을 더한 경우와 안 더한 경우로 분기해서 다시 재귀한다. 이렇게 하면 길이가 1인 부분 수열부터 문제 없이 모든 경우를 고려 가능하다.

## 📚고찰

재귀와 백트래킹의 흐름대로 문제를 해결하는 과정을 어느정도 이해한 것 같다. 하지만 속도는 익숙한 combinations를 활용하는게 훨씬 빨라서 문제마다 다르겠지만 이번 문제는 백트래킹을 이해하고 나중에 활용할 수 있도록 하는 데에만 집중하는게 좋을 것 같다.

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/171e6f6e-44ff-4196-8255-64f7cacbea83/Untitled.png)

위에가 백트래킹 아래가 combinations 풀이이다.

추가적으로 파이썬 변수 유효 범위에 대해서 헷갈렸었는데, 함수 바깥에서 전역으로 선언한 일반 변수에 대해서 함수 내부에서 참조 가능하며, 수정 등의 접근을 위해서 함수 내부에 global로 선언해야한다.