### PR TITLE
[임지수] 2-1 문제 풀이(9095)

### DIFF
--- a/src/chapter2/1_백트래킹(1)/9095_python_임지수.py
+++ b/src/chapter2/1_백트래킹(1)/9095_python_임지수.py
@@ -1,0 +1,27 @@
+import sys
+
+input = sys.stdin.readline
+
+numOfTestcase = int(input())
+
+def back_tracking(res, add):
+    global count
+
+    if res >= n:
+        return
+
+    res += add
+
+    if res == n:
+        count += 1
+
+    back_tracking(res, 1)
+    back_tracking(res, 2)
+    back_tracking(res, 3)
+
+for _ in range(numOfTestcase):
+    count = 0
+    n = int(input())
+
+    back_tracking(0, 0)
+    print(count)


### PR DESCRIPTION
# 9095번 : 1, 2, 3 더하기

특정 수 n(0 < n < 11)가 주어질 때 n을 1, 2, 3의 합으로 나타낼 수 있는 경우의 수를 구하면 되는 문제.

### 🔡 코드

```python
import sys

input = sys.stdin.readline

numOfTestcase = int(input())

def back_tracking(res, add):
    global count

    if res >= n:
        return

    res += add

    if res == n:
        count += 1

    back_tracking(res, 1)
    back_tracking(res, 2)
    back_tracking(res, 3)

for _ in range(numOfTestcase):
    count = 0
    n = int(input())

    back_tracking(0, 0)
    print(count)
```

### 🤨 접근법

백트래킹 방식으로 풀이했다. 처음에 0으로 시작해 각각 1, 2, 3을 더하는 가지를 치는 방법이다. 종료조건은 수를 더하고 다음 재귀 때 `n`을 초과하게 되는 경우 종료이며, 수를 더했을 때  `n`이 되는 경우에 `count`를 증가시켜야 중복 없이 경우의 수를 구할 수 있게 된다.

다른 풀이를 확인하니 DP로 더 많이 풀이하는 것 같아 DP를 학습했을 때 다시 풀어보면 좋을 것 같다.