### PR TITLE
[임지수] 2-1 문제 풀이(9663)

### DIFF
--- a/src/chapter2/1_백트래킹(1)/9663_python_임지수.py
+++ b/src/chapter2/1_백트래킹(1)/9663_python_임지수.py
@@ -1,0 +1,27 @@
+import sys
+
+input = sys.stdin.readline
+
+def promise(idx):
+    for row in range(idx):
+        if board[row] == board[idx] or abs(board[row]-board[idx]) == idx-row:
+                return False
+    return True
+
+def backtracking(idx):
+    global count
+
+    if idx == N:
+        count += 1
+        return
+
+    for i in range(N):
+        board[idx] = i
+        if promise(idx):
+            backtracking(idx+1)
+
+N = int(input())
+count = 0
+board = [-1 for _ in range(N)]
+backtracking(0)
+print(count)


### PR DESCRIPTION
## 🤢 9663번 : N-Queen

### 🐕 개요

NxN 칸에 N개의 퀸을 서로 잡을 수 없게 배치할 수 있는 경우의 수를 구하면 되는 문제

단순히 문제 그대로 NxN 2차원 리스트를 활용해 DFS와 백트래킹으로 해결하려 했으나 구현하지 못했다. 참고 해서 짠 코드를 돌려보니 원래대로 구현 성공했어도 시간초과가 날 것 같았고, 훨씬 복잡하게 구현해야 했을 것 같다.

### 🔡 코드

```python
import sys

input = sys.stdin.readline

def promise(idx):
    for row in range(idx):
        if board[row] == board[idx] or abs(board[idx]-board[row]) == idx-row:
                return False
    return True

def backtracking(idx):
    global count

    if idx == N:
        count += 1
        return

    for i in range(N):
        board[idx] = i
        if promise(idx):
            backtracking(idx+1)

N = int(input())
count = 0
board = [-1 for _ in range(N)]
backtracking(0)
print(count)
```

### 🤨 접근법

퀸의 유효 공격 범위는 해당 행, 열 , 대각선이기 때문에 각 방향에 하나의 퀸만 위치해야 한다.

따라서 하나의 행에 하나의 퀸이 위치해야 함을 활용에 각 행에서의 퀸의 위치를 값으로 하는 하나의 1차원 리스트를 활용할 수 있다. 예를 들어 4x4 보드에서 [0, 3, 2, 1]와 같은 1차원 리스트가 의미하는 바는 

- 0번째 행의 0번째 열
- 1번째 행의 3번째 열
- 2번째 행의 2번째 열
- 3번째 행에 1번째 열

이렇게 퀸을 배치했다는 뜻이다.

이제 0번째 행부터 퀸을 각 열에 배치해가며 DFS를 실시하되, 퀸을 배치해보고(`backtracking()`) 문제에서 제시한 조건에 부합한지 검사(`promise()`)한 뒤, 부합하는 경우에만 계속 진행(`backtracking(idx+1)`)한다. 즉, **백트래킹**을 활용한다.

`promise()`에서의 검사는 체스 보드에서 같은 열에 위치하는 퀸이 있는지, 대각선에 위치하는 퀸이 있는지 만을 추가적으로 검사한다. (1차원 리스트를 활용함으로써 각 행에는 하나의 퀸만 존재함이 성립하므로) 이때 현재 인덱스(`idx` : 새로 퀸을 놓은 위치)를 인자로 넘겨주는데 `idx` 전 까지의 행에만 퀸이 놓여져 있으므로 `idx` 전까지만 순회해서 검사하면 되기 때문이다.(조금의 효율성)

마지막으로 `backtracking(idx)`가 실행될 때 인자로 넘겨받은 idx가 N이 되면 모든 행에 조건에 맞도록 퀸을 배치했음을 의미하므로 전역변수인 `count`에 +1을 해주어 카운트 한다.

## 📚 고찰

해당 문제가 백트래킹을 대표하는 문제 중 하나라는 사실을 알고 있었으며, 이전에 그냥 무작정 풀어본 경험이 있기 때문에 이번 문제를 스스로 풀이하지 못한 것이 아쉬웠다. 특히 1차원 리스트에 체스 보드를 표현하는 방식이 해당 문제에 너무 고착화 된 풀이 방법이라 생각해서 2차원 리스트로 풀어보고자 했지만 둘 다 풀이하지 못했다..

그래도 코드를 참고하는 과정에서 어떤 부분에서 백트래킹 알고리즘을 어떻게 적용하는 지에 대한 감은 확실하게 잡을 수 있었기 때문에 백트래킹(2) 챕터에서는 잘 풀이할 수 있을 것 같다. 

그리고 전역변수로 리스트를 선언한 경우 일반 변수와는 다르게 함수에서 값을 변경하면 전역 리스트 변수의 값도 변경된다. 일반 변수는 값이 복사되어서 함수에 들어가지만 리스트는 주소가 들어가기 때문으로 사료된다.