### PR TITLE
#22 [임지수] 2-3 문제풀이(14889)

### DIFF
--- a/src/chapter2/3_백트래킹(2)/임지수/14889_python_임지수.py
+++ b/src/chapter2/3_백트래킹(2)/임지수/14889_python_임지수.py
@@ -1,1 +1,58 @@
-#2-3 start
+
+''' 풀이 1 : combinations와 반복문을 이용한 풀이
+import sys
+from itertools import combinations
+
+input = sys.stdin.readline
+
+N = int(input())
+ability = [list(map(int, input().rstrip().split())) for _ in range(N)]
+members = set(range(1, N+1))
+team1s = combinations(members, N//2)
+ability_diffs = []
+for team1 in team1s:
+    team2 = set(members)-set(team1)
+    team1s_ability = 0
+    team2s_ability = 0
+    for m1, m2 in combinations(team1, 2):
+        team1s_ability += ability[m1-1][m2-1]
+        team1s_ability += ability[m2-1][m1-1]
+    for m1, m2 in combinations(team2, 2):
+        team2s_ability += ability[m1-1][m2-1]
+        team2s_ability += ability[m2-1][m1-1]
+    ability_diffs.append(abs(team1s_ability-team2s_ability))
+print(min(ability_diffs))
+'''
+# 풀이 2 : DFS와 Back-Tracking을 활용한 풀이
+import sys
+from itertools import combinations
+
+input = sys.stdin.readline
+
+def dfs(idx, team1):
+    global ability_diff
+
+    if len(team1) == N//2:
+        team2 = set(members) - set(team1)
+        team1s_ability = 0
+        team2s_ability = 0
+        for m1, m2 in combinations(team1, 2):
+            team1s_ability += ability[m1][m2]
+            team1s_ability += ability[m2][m1]
+        for m1, m2 in combinations(team2, 2):
+            team2s_ability += ability[m1][m2]
+            team2s_ability += ability[m2][m1]
+        ability_diff = min(ability_diff, abs(team1s_ability-team2s_ability))
+        return
+
+    for i in range(idx, N):
+        team1.append(i)
+        dfs(i, team1)
+        team1.pop()
+
+N = int(input())
+ability = [list(map(int, input().rstrip().split())) for _ in range(N)]
+members = list(range(N))
+ability_diff = int(1e9)
+dfs(0, [])
+print(ability_diff)


### PR DESCRIPTION
## ❓14889번 : 스타트와 링크

전체 인원수 N(짝수)을 입력받고 정확히 두 팀으로 나누는 데, 두 팀의 전력차가 최소가 되도록 나누는 경우의 전력차를 구하면 되는 문제, 이 때 선수 별 전력은 선수와 선수사이의 시너지 수치 행렬로 주어진다.

## 1️⃣ 풀이 1 : combination을 활용한 완전탐색 풀이

### 🔡 코드

```python
import sys
from itertools import combinations

input = sys.stdin.readline

N = int(input())
ability = [list(map(int, input().rstrip().split())) for _ in range(N)]
members = set(range(1, N+1))
team1s = combinations(members, N//2)
ability_diffs = []
for team1 in team1s:
    team2 = set(members)-set(team1)
    team1s_ability = 0
    team2s_ability = 0
    for m1, m2 in combinations(team1, 2):
        team1s_ability += ability[m1-1][m2-1]
        team1s_ability += ability[m2-1][m1-1]
    for m1, m2 in combinations(team2, 2):
        team2s_ability += ability[m1-1][m2-1]
        team2s_ability += ability[m2-1][m1-1]
    ability_diffs.append(abs(team1s_ability-team2s_ability))
print(min(ability_diffs))
```

### 🤨 접근법

combinations를 활용해 N명 중에서 N//2명을 뽑아 team1(`team1`)을 구성하는 모든 경우의 수를 가져온다. 

각 team1의 경우에 대해서 set의 여집합 연산을 활용해 전체 멤버(`members`) - team1을 team2(`team2`)로 한다. 

마찬가지로각 팀에서 2명씩 뽑는 경우를 combinations를 활용해 모두 구한 뒤 시너지 행렬(`ability`)을 인덱스로 참조해 팀 전력(`team1s_ability`, `team2s_ability`)에 모든 선수 조합의 시너지를 더한다.

이렇게 구한 하나의 경우의 두 팀 전력 차를 결과 리스트(`ability_diffs`)에 넣고 마지막에 해당 리스트에서 최소값을 구한다.

## 2️⃣ DFS와 backtracking을 활용한 풀이

현재 진행하고 있는 챕터의 주제가 백트래킹이므로 이를 활용한 풀이도 고안해보았다.

### 🔡 코드

```python
import sys
from itertools import combinations

input = sys.stdin.readline

def dfs(idx, team1):
    global ability_diff

    if len(team1) == N//2:
        team2 = set(members) - set(team1)
        team1s_ability = 0
        team2s_ability = 0
        for m1, m2 in combinations(team1, 2):
            team1s_ability += ability[m1][m2]
            team1s_ability += ability[m2][m1]
        for m1, m2 in combinations(team2, 2):
            team2s_ability += ability[m1][m2]
            team2s_ability += ability[m2][m1]
        ability_diff = min(ability_diff, abs(team1s_ability-team2s_ability))
        return

    for i in range(idx, N):
        team1.append(i)
        dfs(i, team1)
        team1.pop()

N = int(input())
ability = [list(map(int, input().rstrip().split())) for _ in range(N)]
members = list(range(N))
ability_diff = int(1e9)
dfs(0, [])
print(ability_diff)
```

### 🤨 풀이

0번째 선수부터 시작해 다음과 같이 team1에 넣는 경우, 안넣는 경우를 backtracking으로 재귀한다.

```python
for i in range(idx, N):
	team1.append(i)
	dfs(i, team1) # 넣는 경우
	team1.pop()   # 안 넣는 경우 : 빼고 다음 반복 진행
```

team1이 N//2명이 되었을 때 두 팀히 정확히 나뉜 것, 전력차를 구한다.

전력차를 구하는 방식은 풀이 1과 동일하게 진행했다.

다만 이 방식에서 시간초과가 났다. 이미 풀이 1에서 해결한 상태이고 백트래킹을 활용해 문제를 구현하는 데에 초점을 두었기 때문에 그대로 진행했다.

this closes #22 