### PR TITLE
[임지수] 2-4 문제풀이(6588) 풀이

### DIFF
--- a/src/chapter2/4_기초수학(2)/임지수/6588_python_임지수.py
+++ b/src/chapter2/4_기초수학(2)/임지수/6588_python_임지수.py
@@ -1,0 +1,38 @@
+import sys
+
+input = sys.stdin.readline
+
+def get_odd_primenumber_under(n):
+    is_primes = [False, False] + [True for _ in range(2, n+1)]
+    for i in range(2, n+1):
+        j = 2
+        while i*j <= n:
+            if is_primes[i*j]:
+                is_primes[i*j] = False
+            j += 1
+    return [num for num, is_prime in enumerate(is_primes) if is_prime and num % 2 != 0]
+
+odd_primenumbers = get_odd_primenumber_under(1000000)
+
+while True:
+    n = int(input())
+    if n == 0 : break
+    find_flag = False
+    odd_primenumber_under_n = []
+
+    for num in odd_primenumbers:
+        if num > n:
+            break
+        odd_primenumber_under_n.append(num)
+
+    for i in range(len(odd_primenumber_under_n)):
+        for j in range(len(odd_primenumber_under_n)-1, i-1, -1):
+            if odd_primenumber_under_n[i]+odd_primenumber_under_n[j] == n:
+                print(f'{n} = {odd_primenumber_under_n[i]} + {odd_primenumber_under_n[j]}')
+                find_flag = True
+                break
+        if find_flag:
+            break
+
+    if not find_flag:
+        print("Goldbach's conjecture is wrong.")


### PR DESCRIPTION
## ❓6588번 : 골드바흐의 추측

짝수 n(6≤ n ≤ n)이 두 홀수 소수의 합으로 나타낼 수 있으면, 두 소수의 차이가 가장 큰 경우를 출력하면 되는 문제

### 🔡 코드

```python
import sys

input = sys.stdin.readline

def get_odd_primenumber_under(n):
    is_primes = [False, False] + [True for _ in range(2, n+1)]
    for i in range(2, n+1):
        j = 2
        while i*j <= n:
            if is_primes[i*j]:
                is_primes[i*j] = False
            j += 1
    return [num for num, is_prime in enumerate(is_primes) if is_prime and num % 2 != 0]

odd_primenumbers = get_odd_primenumber_under(1000000)

while True:
    n = int(input())
    if n == 0 : break
    find_flag = False
    odd_primenumber_under_n = []

    for num in odd_primenumbers:
        if num > n:
            break
        odd_primenumber_under_n.append(num)

    for i in range(len(odd_primenumber_under_n)):
        for j in range(len(odd_primenumber_under_n)-1, i-1, -1):
            if odd_primenumber_under_n[i]+odd_primenumber_under_n[j] == n:
                print(f'{n} = {odd_primenumber_under_n[i]} + {odd_primenumber_under_n[j]}')
                find_flag = True
                break
        if find_flag:
            break

    if not find_flag:
        print("Goldbach's conjecture is wrong.")
```

### 🤨 접근법

n이하의 모든 홀수인 소수를 고려해야 하기 때문에 에라토스테네스의 체 알고리즘을 이용하되 홀수인 소수만 반환 하도록 했다(`get_odd_primenumber_under(n)`).

여기서 중요한 점은 해당 문제에서 테스트 케이스가 여러 줄에 걸쳐 주어지는데, 매번 위 함수를 실행시켜 소수를 구하면 시간 초과가 발생한다. 따라서 n = 1,000,000일 때 함수 한 번으로 문제의 유효 범위 내 홀수 소수를 모두 구한 후 주어지는 테스트 케이스 n에 맞춰 파싱해야 한다. ( `odd_primenumber_under_n`)

n이하의 홀수 소수를 모두 구했으면 이제 두 수의 조합을 모두 고려해야 하는데, 문제에서는 두 수의 합이 n이 되는 경우가 여러 개인 경우 두 수의 차가 가장 큰 경우를 출력해야 한다. 그렇기 때문에 하나의 수는 앞에서(`i`), 하나의 수는 뒤에서(`j`) 접근하여 가장 먼저 만들어 지는 n을 출력하도록 하면 된다.

출력 후 이중 반복문을 flag 변수를 활용해 빠져나올 수 있도록 구현했다.

+) Python3 컴파일러로 실행시 시간초과가 발생했지만, pypy로 실행시 통과할 수 있었다.

and this closes #38 