### PR TITLE
[임지수] 2-4 문제풀이(1016)

### DIFF
--- a/src/chapter2/4_기초수학(2)/임지수/1016_python_임지수.py
+++ b/src/chapter2/4_기초수학(2)/임지수/1016_python_임지수.py
@@ -1,0 +1,20 @@
+import sys
+
+input = sys.stdin.readline
+
+min_, max_ = map(int, input().rstrip().split())
+
+check_range = [False for _ in range(min_, max_+1)]
+count = len(check_range)
+i = 2
+while i*i <= max_:
+    square = i*i
+    j = min_//square if min_%square==0 else min_//square+1
+    while square*j <= max_:
+        if not check_range[min_-square*j]:
+            check_range[min_-square*j] = True
+            count -= 1
+        j += 1
+    i += 1
+
+print(count)


### PR DESCRIPTION
## 😒 1016번 : 제곱ㄴㄴ수

다음 조건의 두 정수 min, max가 주어질 때 (min, max) 범위 내 제곱ㄴㄴ수의 개수를 구하면 되는 문제

- 1 ≤ min ≤ 1,000,000,000,000
- min ≤ max ≤ min + 1,000,000

제곱ㄴㄴ수는 1이상의 제곱수(4, 9, 16, …)로 나뉘어 지지 않는 수로 정의된다.

### 🔡 코드

```python
import sys

input = sys.stdin.readline

min_, max_ = map(int, input().rstrip().split())

check_range = [False for _ in range(min_, max_+1)]
count = len(check_range)
i = 2
while i*i <= max_:
    square = i*i
    j = min_//square if min_%square==0 else min_//square+1
    while square*j <= max_:
        if not check_range[min_-square*j]:
            check_range[min_-square*j] = True
            count -= 1
        j += 1
    i += 1

print(count)
```

### 🤨 접근법

에라토스테네스의 체 알고리즘에서 소수 판정 → 제곱수 판정으로 응용한 풀이이다. 제곱수의 배수는 제곱수이므로, 소수 판정에서 2의 배수, 3의 배수, …, $\sqrt n$의 배수를 지워가듯 여기서는 4의 배수, 9의 배수, … 를 지우는 것이다.

문제는 주어지는 범위 (min, max)의 범위이다. min이 작은 수라면 문제가 없겠지만 min은 1,000,000,000,000까지 될 수 있으므로 처음 부터 접근하면 분명 메모리가 터지거나 시간 초과가 되거나 둘 중 하나이다.

여기서 포인트는 **제곱수의 배수**를 지운다는 것인데, 제곱수의 배수를 `square`(i*i) * `j` 같이 구해서 지운다면, `j`를 적절히 정의해 구하고자 하는 범위 내부터 제곱수의 배수를 지우면 된다. 이렇게 해야 최대 10,000개의 수만 체크할 수 있다.

예를 들어 min = 50, max = 60인 경우, 제거되는 제곱수는 다음과 같다.

- 4의 제곱수 : 52(4*13), 56(4*14), 60(4*15)
- 9의 제곱수 : 54(9*6)
- 25의 제곱수 : 50 (25*2)

따라서 첫 번째 j를 다음과 같이 정의하면 범위 내의 숫자부터 체크가 가능하다.

- j = min//(i*i) ((min%(i*i) == 0)
- j = min//(i*i)+1 (min%(i*i) ≠ 0) 

위와 같은 방식으로 i와 j를 증가시켜가며 범위 내 모든 제곱수의 배수를 check 배열(`check_range`)에서 True로 만들어 준다.

모든 연산이 끝난 후 False인 경우만 모두 세서 결과를 얻으면 다시 O(n)의 연산이 필요하므로 처음에 범위내 수의 개수에서 어떤 수를 False → True로 만들어 줄 때 하나씩 빼어 최종 결과(`count`)를 얻어낸다.

## 📚 고찰

에라토스테네스의 체 알고리즘은 범위 내 소수를 판정하는 알고리즘 중 하나에 해당하지 소수 만을 판정하기 위한 알고리즘은 아니다. 범위 내 조건에 맞는 수를 구해야 할 때 이번 문제와 같은 방식으로 응용해 어떤 범위 내의 어떤 조건의 수를 효과적으로 필터링해낼 수 있다.

문제에 대해 접근할 때 조금은 직관적이고 원초적으로 접근할 필요가 있을 것 같다.

and This closes #40 