### PR TITLE
[임지수] 3-1 문제 풀이(2667)

### DIFF
--- a/src/chapter3/1_DFS와BFS(1)/2667_python_임지수.py
+++ b/src/chapter3/1_DFS와BFS(1)/2667_python_임지수.py
@@ -1,0 +1,41 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+N = int(input())
+MAP = [list(input()) for _ in range(N)]
+dx = [0, 0, -1, 1]
+dy = [-1, 1, 0, 0]
+results = []
+
+def bfs(row, col):
+
+    if MAP[row][col] == '1':
+        queue = deque([(row, col)])
+        MAP[row][col] = '0'
+        count = 1
+    else:
+        queue = deque([])
+        count = 0
+
+    while queue:
+        y, x = queue.popleft()
+        for i in range(4):
+            ny, nx = y+dy[i], x+dx[i]
+            if 0 <= ny <= N-1 and 0 <= nx <= N-1:
+                if MAP[ny][nx] == '1':
+                    queue.append((ny, nx))
+                    MAP[ny][nx] = '0'
+                    count += 1
+    return count
+
+for r in range(N):
+    for c in range(N):
+         result = bfs(r, c)
+         if result != 0:
+             results.append(result)
+
+print(len(results))
+for num in sorted(results):
+    print(num)


### PR DESCRIPTION
## ❓2667번 : 단지번호붙이기

주어지는 NxN 맵에서 1은 집이 있는 곳, 0은 집이 없는 곳을 나타낼 때, 연결된 집의 모임을 정의하는 단지의 수와, 각 단지의 집의 수를 오름차순으로 출력하면 되는 문제

### 🔡 코드

```python
import sys
from collections import deque

input = sys.stdin.readline

N = int(input())
MAP = [list(input()) for _ in range(N)]
dx = [0, 0, -1, 1] # 상 하 좌 우
dy = [-1, 1, 0, 0]
results = []

def bfs(row, col):

    if MAP[row][col] == '1':
        queue = deque([(row, col)])
        MAP[row][col] = '0'
        count = 1
    else:
        queue = deque([])
        count = 0

    while queue:
        y, x = queue.popleft()
        for i in range(4): # 상 하 좌 우
            ny, nx = y+dy[i], x+dx[i]
            if 0 <= ny <= N-1 and 0 <= nx <= N-1:
                if MAP[ny][nx] == '1':
                    queue.append((ny, nx))
                    MAP[ny][nx] = '0'
                    count += 1
    return count

for r in range(N):
    for c in range(N):
         result = bfs(r, c)
         if result != 0:
             results.append(result)

print(len(results))
for num in sorted(results):
    print(num)
```

### 🤨 접근법

`MAP`의 각 좌표에서 **BFS**로 연결된 집을 탐색한다. 이 때, 어떤 집을 처음으로 탐색하게 되면 별도 visited 배열 없이 해당 좌표 값을 ‘1’에서 ‘0’으로 바꿔줌으로서 방문했음을 표시한다. 그러면 다음 좌표에서 BFS를 실행해도 중복 없이 단지를 탐색할 수 있다.

어떤 좌표 (row, col)에서 bfs 실행 시 우선 처음 시작 좌표(row, col)가 집인지를 체크해야 한다. 집이라면 큐에 넣어 인접한 집들을 탐색하게 되고, 집이 아니라면 다음 좌표에서 BFS를 해본다.

and this closes #47 