### PR TITLE
[임지수] 3-1 문제 풀이(1697)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Made with [contrib.rocks](https://contrib.rocks).
 | 2 | 2 | 기초 수학(1) | [1037](https://www.acmicpc.net/problem/1037), [1978](https://www.acmicpc.net/problem/1978), [1929](https://www.acmicpc.net/problem/1929), [2609](https://www.acmicpc.net/problem/2609)                                                                                                     | 에라토스테네스의 체, 유클리드 호제법 |
 | 2 | 3 | 백트래킹(2) | [14889](https://www.acmicpc.net/problem/14889), [15686](https://www.acmicpc.net/problem/15686), [2661](https://www.acmicpc.net/problem/2661), [2580](https://www.acmicpc.net/problem/2580)                                                                                                 | X |
 | 2 | 4 | 기초 수학(2) | [2485](https://www.acmicpc.net/problem/2485), [1644](https://www.acmicpc.net/problem/1644), [6588](https://www.acmicpc.net/problem/6588), [15711](https://www.acmicpc.net/problem/15711), [1016](https://www.acmicpc.net/problem/1016)                                                     | X |
-| 3 | 1 | DFS와 BFS(1) | [1260](https://www.acmicpc.net/problem/1260), [2667](https://www.acmicpc.net/problem/2667), [1967](https://www.acmicpc.net/problem/1967), [2178](https://www.acmicpc.net/problem/2178), [2606](https://www.acmicpc.net/problem/2606) | DFS, BFS |
+| 3 | 1 | DFS와 BFS(1) | [1260](https://www.acmicpc.net/problem/1260), [2667](https://www.acmicpc.net/problem/2667), [1697](https://www.acmicpc.net/problem/1697), [2178](https://www.acmicpc.net/problem/2178), [2606](https://www.acmicpc.net/problem/2606)                                                       | DFS, BFS |
 ### 개인 진행 사항
 
 | ⭕❌❗▶️ | 지수 | 승화 |

--- a/src/chapter3/1_DFS와BFS(1)/1697_python_임지수.py
+++ b/src/chapter3/1_DFS와BFS(1)/1697_python_임지수.py
@@ -1,0 +1,22 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+N, K = map(int, input().rstrip().split())
+
+MAP = [False for _ in range(0, 100001)]
+
+def bfs():
+    queue = deque([(N, 0)])
+    MAP[N] = True
+    while queue:
+        x, cnt = queue.popleft()
+        if x == K:
+            return cnt
+
+        for nx in [x+1, x-1, 2*x]:
+            if 0 <= nx <= 100000 and not MAP[nx]:
+                queue.append((nx, cnt+1))
+                MAP[nx] = True
+print(bfs())


### PR DESCRIPTION
## ❓1697번 : 숨바꼭질

현재 좌표 x에서 1회 이동으로 [x+1, x-1, 2*x] 좌표로 이동할 수 있을 때 주어지는 좌표 K까지 걸리는 최소 이동 횟수를 구하면 되는 문제

### 🔡 코드

```python
import sys
from collections import deque

input = sys.stdin.readline

N, K = map(int, input().rstrip().split())

MAP = [False for _ in range(0, 100001)]

def bfs():
    queue = deque([(N, 0)])
    MAP[N] = True
    while queue:
        x, cnt = queue.popleft()
        if x == K:
            return cnt

        for nx in [x+1, x-1, 2*x]:
            if 0 <= nx <= 100000 and not MAP[nx]:
                queue.append((nx, cnt+1))
                MAP[nx] = True
print(bfs())
```

### 🤨 접근법

현재 좌표 x에서 x+1, x-1, 2*x로 이동한 경우를 트리로 나타내면 트리의 레벨이 이동 횟수이다. 모든 경우를 고려하며 트리를 만들어 탐색하되, 이미 다른 트리 경로에서 방문한 좌표는 다른 경로에서 재방문할 경우 최소 이동 횟수가 절대 될 수 없으므로 이동하지 않아도 된다.(이동시 메모리 초과)

트리 순회 과정은 BFS로 구현했다. queue에 다음 좌표와 현재 레벨+1을 함께 넣어주어 다음 queue에서 좌표를 꺼낼 때 해당 좌표가 K일 때의 cnt를 반환하도록 했다.

[BFS 정리](https://www.notion.so/BFS-Breadth-First-Search-61962e7e923343938d5ba08524a76b5d)에서 최단 경로의 길이를 찾아야 하는 문제에 BFS를 활용할 수 있다고 했는데, 그 예시가 되는 문제였다.

and this closes #48 