### PR TITLE
[임지수] 3-1 문제 풀이(2178)

### DIFF
--- a/src/chapter3/1_DFS와BFS(1)/2178_python_임지수.py
+++ b/src/chapter3/1_DFS와BFS(1)/2178_python_임지수.py
@@ -1,0 +1,23 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N, M = map(int, input().rstrip().split())
+MAP = [list(input()) for _ in range(N)]
+dy = [-1, 1, 0, 0]
+dx = [0, 0, -1, 1]
+
+def bfs():
+    queue = deque([(0, 0, 1)])
+    while queue:
+        row, col, cnt = queue.popleft()
+        if row == N-1 and col == M-1:
+            return cnt
+        for i in range(4):
+            ny, nx = row+dy[i], col+dx[i]
+            if 0 <= ny < N and 0 <= nx < M:
+                if MAP[ny][nx] == '1':
+                    queue.append((ny, nx, cnt+1))
+                    MAP[ny][nx] = '0'
+
+print(bfs())


### PR DESCRIPTION
## ❓2178번 : 미로탐색

1, 1 좌표에서 N, M까지 경로 중 가장 짧은 거리를 출력하면 되는 문제

여기서 1, 1은 인덱스 상으로 0, 0

### 🔡 코드

```python
import sys
from collections import deque
input = sys.stdin.readline

N, M = map(int, input().rstrip().split())
MAP = [list(input()) for _ in range(N)]
dy = [-1, 1, 0, 0]
dx = [0, 0, -1, 1]

def bfs():
    queue = deque([(0, 0, 1)])
    while queue:
        row, col, cnt = queue.popleft()
        if row == N-1 and col == M-1:
            return cnt
        for i in range(4):
            ny, nx = row+dy[i], col+dx[i]
            if 0 <= ny < N and 0 <= nx < M:
                if MAP[ny][nx] == '1':
                    queue.append((ny, nx, cnt+1))
                    MAP[ny][nx] = '0'

print(bfs())
```

### 🤨 접근법

최단 길이 경로를 구하는 문제이므로 [이전 문제](https://www.notion.so/3d1f42fcc7b046279b514a97f28fcc6a)와 동일하게 BFS로 접근하여 큐에 좌표와 함께 해당 레벨을 관리하도록 했다. 특별한 조건이나 예외 조건 등은 없는 문제였고, 문제에서 제시한 좌표 (1,1)이 인덱스 상으로 (0, 0)인 점만 주의해서 코드를 작성하면 되었다.

and this closes #49 