### PR TITLE
[임지수] 3-1 문제 풀이(2606)

### DIFF
--- a/src/chapter3/1_DFS와BFS(1)/2606_python_임지수.py
+++ b/src/chapter3/1_DFS와BFS(1)/2606_python_임지수.py
@@ -1,0 +1,28 @@
+import sys
+from collections import deque, defaultdict
+
+input = sys.stdin.readline
+
+N = int(input())
+M = int(input())
+connect_map = defaultdict(deque)
+for _ in range(M):
+    node1, node2 = map(int, input().rstrip().split())
+    connect_map[node1].append(node2)
+    connect_map[node2].append(node1)
+visited = [False for _ in range(N+1)]
+
+def bfs():
+    queue = deque([1])
+    visited[1] = True
+    cnt = 0
+    while queue:
+        node = queue.pop()
+        for near_node in connect_map[node]:
+            if not visited[near_node]:
+                queue.append(near_node)
+                visited[near_node] = True
+                cnt += 1
+    return cnt
+
+print(bfs())


### PR DESCRIPTION
## ❓2606번 : 바이러스

1번 컴퓨터(노드)가 연결되어있는 네트워크 내의 컴퓨터의 수를 구하면 되는 문제

### 🔡 코드

```python
import sys
from collections import deque, defaultdict

input = sys.stdin.readline

N = int(input())
M = int(input())
connect_map = defaultdict(deque)
for _ in range(M):
    node1, node2 = map(int, input().rstrip().split())
    connect_map[node1].append(node2)
    connect_map[node2].append(node1)
visited = [False for _ in range(N+1)]

def bfs():
    queue = deque([1])
    visited[1] = True
    cnt = 0
    while queue:
        node = queue.pop()
        for near_node in connect_map[node]:
            if not visited[near_node]:
                queue.append(near_node)
                visited[near_node] = True
                cnt += 1
    return cnt

print(bfs())
```

### 🤨 접근법

단순히 1번 노드가 연결된 경로의 노드 수를 구하면 되는 문제였다.

노드 연결 맵은 dict형태로 입력 받았고, defalutdict(deque)을 활용해 입력 받자마자 연결된 노드를 관리하는 리스트에 append하도록 구현했다.

이후 연결 맵을 BFS로 탐색했고, 1번 노드가 포함된 경로만 탐색하면 되므로, 한 번의 탐색으로 수를 구해낼 수 있다.

and this closes #50 