### PR TITLE
[임지수] 3-2 문제 풀이(1463)

### DIFF
--- a/src/chapter3/2_기초다이나믹프로그래밍(1)/임지수/1463_python_임지수.py
+++ b/src/chapter3/2_기초다이나믹프로그래밍(1)/임지수/1463_python_임지수.py
@@ -1,0 +1,26 @@
+import sys
+
+input = sys.stdin.readline
+
+X = int(input())
+dp = [0 for _ in range(X+1)]
+
+for idx in range(2, X+1):
+    if idx%6 == 0:
+        dp[idx] = min(dp[idx-1]+1, dp[idx//3]+1, dp[idx//2]+1)
+    elif idx%3 == 0:
+        dp[idx] = min(dp[idx-1]+1, dp[idx//3]+1)
+    elif idx%2 == 0:
+        dp[idx] = min(dp[idx-1]+1, dp[idx//2]+1)
+    else:
+        dp[idx] = dp[idx-1]+1
+
+''' 죄적화
+for idx in range(2, X+1):
+	dp[idx] = dp[idx-1]+1
+	if idx%3 == 0:
+		dp[idx] = min(dp[idx], dp[idx//3]+1)
+    if idx%2 == 0:
+        dp[idx] = min(dp[idx], dp[idx//2]+1)
+'''
+print(dp[X])


### PR DESCRIPTION
## ❓1463번 : 1로 만들기

정수 N을 다음 3가지 연산을 반복해 1로 만들 때, 가장 최소 연산 횟수를 구하면 되는 문제

1. X가 3으로 나누어 떨어지면, 3으로 나눈다.
2. X가 2로 나누어 떨어지면, 2로 나눈다.
3. 1을 뺀다.

### 🔡 코드

```python
import sys

input = sys.stdin.readline

X = int(input())
dp = [0 for _ in range(X+1)]

for idx in range(2, X+1):
    if idx%6 == 0:
        dp[idx] = min(dp[idx-1]+1, dp[idx//3]+1, dp[idx//2]+1)
    elif idx%3 == 0:
        dp[idx] = min(dp[idx-1]+1, dp[idx//3]+1)
    elif idx%2 == 0:
        dp[idx] = min(dp[idx-1]+1, dp[idx//2]+1)
    else:
        dp[idx] = dp[idx-1]+1
print(dp[X])
```

### 🤨 접근법

- N = 2일 경우 2 → 1 : 1회
- N = 3일 경우 3 → 1 : 1회

이 **두 기저 조건**과, 

- N = 9일 경우 9 → 3 → 1 : 3회
- N = 10일 경우 10 → 9 → 3 → 1 : 4회로, 9까지의 **최적 부분이 전체 결과에 그대로 반영**되므로 명백한 **dp 문제**라고 할 수 있다.

문제는 두 기저 조건을 이용해 **Bottom-Up**으로 **테이뷸레이션**을 진행할 때 모든 경우에 대해서 무조건 3이나 2로 나눈 값에 횟수 1을 더한 것이 **최적인지는 모른다**는 것이다.

예를 들어 N=10일 때, 무작정 2부터 나눠서 10 → 5 → 4 → 2 → 1 과 같이 4회 연산을 하는 것 보다, 1을 빼어 10 → 9 → 3 → 1과 같이 3회 연산을 하는 것이 최소이다.

어떤 것이 최적인지 알기  위해서는 직접 비교를 해봐야 한다.

테이뷸레이션 진행시 2or3의 배수인지 판별 후 약수라면 해당 수로 나눴을 때 연산 횟수에 + 1한 횟수와, 1을 빼었을 때 연산 횟수에 +1한 횟수 중 **더 낮은 값**을 선택해야 한다.

위 코드에서 6의 배수인지 먼저 판별한 이유는 6의 배수라면 2로도 나눠지고 3으로도 나눠지는데, 어떤 수로 먼저 나눠야 최소 연산 횟수로 나눌 수 있는지 조차 모르기 때문이다. 따라서 이 경우 1을 빼었을 때 횟수 + 1, 2로 나눴을 때 횟수 + 1, 3으로 나눴으로 때 횟수 + 1 중 최소를 고른다.

이 과정을 아래같이 최적화 하여 코드를 작성할 수도 있다.

```python
for idx in range(2, X+1):
		dp[idx] = dp[idx-1]+1
		if idx%3 == 0:
			dp[idx] = min(dp[idx], dp[idx//3]+1)
    if idx%2 == 0:
        dp[idx] = min(dp[idx], dp[idx//2]+1)
```

and this closes #57 