### PR TITLE
[임지수] 3-2 문제 풀이(2579)

### DIFF
--- a/src/chapter3/2_기초다이나믹프로그래밍(1)/임지수/2579_python_임지수.py
+++ b/src/chapter3/2_기초다이나믹프로그래밍(1)/임지수/2579_python_임지수.py
@@ -1,0 +1,21 @@
+import sys
+
+input = sys.stdin.readline
+
+N = int(input())
+stairs = [int(input()) for _ in range(N)]
+dp = [-1 for _ in range(N)]
+
+try:
+    dp[0] = stairs[0]
+    dp[1] = max(stairs[0]+stairs[1], stairs[1])
+    dp[2] = max(stairs[0]+stairs[2], stairs[1]+stairs[2])
+
+    for i in range(3, N):
+        dp[i] = max(dp[i-2]+stairs[i], dp[i-3]+stairs[i-1]+stairs[i])
+
+except IndexError:      # N < 3일 경우 예외 처리
+    pass
+
+finally:
+    print(dp[-1])


### PR DESCRIPTION
## ❓ 2579번 : 계단 오르기

다음 규칙을 준수하여 계단을 오를 때, 계단에 있는 점수의 합이 가장 높도록 계단을 오르는 경우의 점수를 구하면 되는 문제

1. 계단은 한 번에 한 계단씩 또는 두 계단씩 오를 수 있다. 즉, 한 계단을 밟으면서 이어서 다음 계단이나, 다음 다음 계단으로 오를 수 있다.
2. 연속된 세 개의 계단을 모두 밟아서는 안 된다. 단, 시작점은 계단에 포함되지 않는다.
3. 마지막 도착 계단은 반드시 밟아야 한다.

### 🔡 코드

```python
import sys

input = sys.stdin.readline

N = int(input())
stairs = [int(input()) for _ in range(N)]
dp = [-1 for _ in range(N)]

try:
    dp[0] = stairs[0]
    dp[1] = max(stairs[0]+stairs[1], stairs[1])
    dp[2] = max(stairs[0]+stairs[2], stairs[1]+stairs[2])

    for i in range(3, N):
        dp[i] = max(dp[i-2]+stairs[i], dp[i-3]+stairs[i-1]+stairs[i])

except IndexError:      # N < 3일 경우 예외 처리
    pass

finally:
    print(dp[-1])
```

### 🤨 접근법

가장 중요한 점은 규칙 3 : 마지막 도착 계단은 반드시 밟는다는 점이다. 이 점에 초점을 맞춰 i번째 계단을 밟는다고 하면 다음 두 경우를 고려할 수 있다.

1. 직전에 i-2번 째 계단을 밟았을 경우
2. 직전에 i-1번 째 계단을 밟았을 경우

경우 1에서는 i-2번 째 계단 이전에 어떤 계단을 밟았던 상관 없지만 경우 2에서는 i-1번 째 계단 이전은 꼭 i-3번 째 계단을 밟았어야 한다. 그렇기 때문에 dp[i]가 i번째 계단까지 갈 때의 최대 점수라면 위 두 경우는 다음과 같이 나타낼 수 있다.

1. dp[i-2]+stairs[i]
2. dp[i-3]+stairs[i-1]+stairs[i]

이 두 경우 중 더 큰 경우가 i번 째 계단 까지 최대 점수를 얻을 수 있는 경우이다.

알고리즘 작성을 위해 i-3 경우까지 고려해야 하므로 dp[0]~dp[2]까지는 하드 코딩으로 직접 입력해주어야하는 작업이 필요하다. 이 때 N=1인 입력이 들어올 경우 dp[2]를 구하는 과정에서 IndexError가 발생할 수 있다. 이를 위해 N<3일 경우 IndexError에 대한 예외 처리를 추가적으로 진행했다.

## 📚 고찰

이번 문제를 풀면서 다음 두 가지를 비교적 크게 느꼈다.

1. dp 문제인지 모르고 풀었으면 재귀를 활용한 백트래킹으로 접근했을 것 같다.
2. dp임을 알아도 어떻게 접근해야 할지 아직 감이 잡히지 않는다.

1의 경우는 실전에서 맞닥뜨리게 되면 시행착오로 시간초과가 발생할 수 있다. 문제를 더 잘 분석해서 dp를 활용할 경우 더 좋은 문제임을 빠르게 파악할 수 있는 것이 중요한 것 같다.

2의 경우는 dp에 익숙해져야 하는데, 시간이 더 필요할 것 같다.

결론은 문제를 많이 푸는 수 밖에 없을 것 같다. 조급해 하지 말고 천천히 꾸준히만 해나갑시다.

and this closes #58 